### PR TITLE
Sponsors, instrukcja dla Windows. Bez danych yml.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,10 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.15.5)
+    ffi (1.15.5-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
     google-protobuf (3.21.12)
+    google-protobuf (3.21.12-x64-mingw-ucrt)
     google-protobuf (3.21.12-x86_64-darwin)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
@@ -64,15 +66,23 @@ GEM
     safe_yaml (1.0.5)
     sass-embedded (1.57.1-arm64-darwin)
       google-protobuf (~> 3.21)
+    sass-embedded (1.57.1-x64-mingw-ucrt)
+      google-protobuf (~> 3.21)
     sass-embedded (1.57.1-x86_64-darwin)
       google-protobuf (~> 3.21)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2022.7)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.4.2)
+    wdm (0.1.1)
     webrick (1.7.0)
 
 PLATFORMS
   arm64-darwin-22
+  x64-mingw-ucrt
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -26,7 +26,22 @@ Then:
 bundle install
 ```
 
+On Windows:
+
+1. Install RubyInstaller with DevKit from https://rubyinstaller.org/. Follow the step-by-step instructions and install the default components.
+2. Open a command prompt or PowerShell window and navigate to the project directory.
+3. Install the required version of bundler and dependencies by running the following commands:
+```
+gem install jekyll
+gem install bundler -v '2.4.5'
+bundle _2.4.5_ install
+```
+> Note: By default, `bundle install` may try to run a `bundle.js` file in your root directory. If this happens, you may want to move this file temporarily. 
+
+
 ### Run server with livereload
+After bundler has finished installing the required gems, you can start the Jekyll server by running:
 ```
 bundle exec jekyll serve --livereload
 ```
+This should start the server and make your website available at http://localhost:4000.

--- a/_includes/conference/nav.html
+++ b/_includes/conference/nav.html
@@ -30,6 +30,9 @@
                         <a class="page-scroll" href="#timeline">/ Timeline</a>
                     </li>
                     <li>
+                        <a class="page-scroll" href="#sponsors">/ Sponsors</a>
+                    </li>
+                    <li>
                         <a class="page-scroll" href="#organizers">/ Organizers</a>
                     </li>
                     <li>

--- a/_includes/conference/sponsors.html
+++ b/_includes/conference/sponsors.html
@@ -1,0 +1,146 @@
+<!-- Sponsors Section -->
+<section id="sponsors" class="container content-section">
+    <!-- Strategic Sponsors -->
+    {% if site.data.sponsors.strategic %}
+    <div class="row">
+        <div class="col-lg-12">
+            <h2 class="text-align-left">/ Strategic Sponsors</h2>
+        </div>
+        <div class="row d-flex justify-content-center text-center">
+            {% for sponsor in site.data.sponsors.strategic %}
+            <div class="col-md-6 ">
+                <div class="feature">
+                    {% if sponsor.link %}
+                    <a href="{{ sponsor.link }}" target="_blank">
+                        <img class="width-100" width="600" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    </a>
+                    {% else %}
+                    <img class="width-100" width="600" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Platinum Sponsors -->
+    {% if site.data.sponsors.platinum %}
+    <div class="row mt-2">
+        <div class="col-lg-12">
+            <h2 class="text-align-left">/ Platinum Sponsors</h2>
+        </div>
+        <div class="row d-flex justify-content-center text-center">
+            {% for sponsor in site.data.sponsors.platinum %}
+            <div class="col-sm-4 ">
+                <div class="feature">
+                    {% if sponsor.link %}
+                    <a href="{{ sponsor.link }}" target="_blank">
+                        <img class="width-100" width="420" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    </a>
+                    {% else %}
+                    <img class="width-100" width="420" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Gold Sponsors -->
+    {% if site.data.sponsors.gold %}
+    <div class="row mt-2">
+        <div class="col-lg-12">
+            <h2 class="text-align-left" style="font-size: 27px;">/ Gold Sponsors</h2>
+        </div>
+        <div class="row d-flex justify-content-center text-center">
+            {% for sponsor in site.data.sponsors.gold %}
+            <div class="col-sm-4 ">
+                <div class="feature">
+                    {% if sponsor.link %}
+                    <a href="{{ sponsor.link }}" target="_blank">
+                        <img class="width-100" width="290" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    </a>
+                    {% else %}
+                    <img class="width-100" width="290" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Silver Sponsors -->
+    {% if site.data.sponsors.silver %}
+    <div class="row mt-2">
+        <div class="col-lg-12">
+            <h2 class="text-align-left" style="font-size: 25px;">/ Silver Sponsors</h2>
+        </div>
+        <div class="row d-flex justify-content-center text-center">
+            {% for sponsor in site.data.sponsors.silver %}
+            <div class="col-sm-3 ">
+                <div class="feature">
+                    {% if sponsor.link %}
+                    <a href="{{ sponsor.link }}" target="_blank">
+                        <img class="width-100" width="250" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    </a>
+                    {% else %}
+                    <img class="width-100" width="250" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Partners -->
+    {% if site.data.sponsors.partner %}
+    <div class="row mt-5">
+        <div class="col-lg-12">
+            <h2 class="text-align-left">/ Partners</h2>
+        </div>
+        <div class="row d-flex justify-content-center text-center">
+            {% for sponsor in site.data.sponsors.partner %}
+            <div class="col-sm-3 ">
+                <div class="feature">
+                    {% if sponsor.link %}
+                    <a href="{{ sponsor.link }}" target="_blank">
+                        <img class="width-100" width="250" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    </a>
+                    {% else %}
+                    <img class="width-100" width="250" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Honorary Patronages -->
+    {% if site.data.sponsors.patronage %}
+    <div class="row mt-5">
+        <div class="col-lg-12">
+            <h2 class="text-align-left">/ Honorary Patronages</h2>
+        </div>
+        <div class="row d-flex justify-content-center text-center">
+            {% for sponsor in site.data.sponsors.patronage %}
+            <div class="col-sm-6">
+                <div class="feature">
+                    {% if sponsor.link %}
+                    <a href="{{ sponsor.link }}" target="_blank">
+                        <img class="width-100" width="320" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    </a>
+                    {% else %}
+                    <img class="width-100" width="320" src="{{ sponsor.image | relative_url }}" alt="{{ sponsor.name }} logo">
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+</section>

--- a/_includes/css/mlinpl.css
+++ b/_includes/css/mlinpl.css
@@ -400,6 +400,14 @@ ul.banner-social-buttons li {
     ul.banner-social-buttons li:last-child {
         margin-bottom: 0;
     }
+
+    .feature {
+        margin-bottom: 30px;
+    }
+
+    #sponsors img {
+        padding: 3% 0 0 !important;
+    }
 }
 
 footer {
@@ -541,4 +549,43 @@ body {
     25% {opacity: 0;}
     92% {opacity: 0;}
     100% {opacity: 1;}
+}
+
+.feature {
+    margin-bottom: 60px;
+}
+
+#sponsors a {
+    display: inline-block;
+    width: 100%;
+}
+
+#sponsors img {
+    padding: 5%;
+}
+
+.justify-content-center {
+    -webkit-box-pack: center !important;
+    -ms-flex-pack: center !important;
+    justify-content: center !important;
+}
+
+.d-flex {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+}
+
+.text-align-left {
+    text-align: left;
+}
+
+.mt-5 {
+    margin-top: 3rem !important;
+}
+
+.mt-2 {
+    margin-top: 0.5rem !important;
 }

--- a/_layouts/conference.html
+++ b/_layouts/conference.html
@@ -6,6 +6,7 @@
     {% include conference/header.html %}
     {% include conference/about.html %}
     {% include conference/timeline.html %}
+    {% include conference/sponsors.html %}
     {% include conference/organizers.html %}
     {% include contact.html %}
     {% include footer.html %}


### PR DESCRIPTION
Dane .yml do testowania podane w dm na Slack.

Sponsorów/partnerów/patronów możemy dodawać na bieżąco, ale potrzebna nam jest chociaż jedna kategoria (odpowiednie sekcje są w blokach "if".
Bez danych nie wyświetli się żadna sekcja.